### PR TITLE
Fix for readlink for .host:/<something> mounts

### DIFF
--- a/open-vm-tools/vmhgfs-fuse/main.c
+++ b/open-vm-tools/vmhgfs-fuse/main.c
@@ -334,8 +334,8 @@ hgfs_readlink(const char *path, //IN: path to a file
    }
 
    if (size >= strlen(attr->fileName)) {
-      Str_Strcpy(buf, attr->fileName + gState->basePathLen,
-                 strlen(attr->fileName) + 1 - gState->basePathLen);
+      Str_Strcpy(buf, attr->fileName,
+                 strlen(attr->fileName) + 1);
    } else {
       res = -ENOBUFS;
    }


### PR DESCRIPTION
Readlink returns just raw value of link target and in most cases it's relative filename.

But even if it's an absolute filename it can be our prefix or some completely different thing so it's not safe to just remove prefixLen chars from it.

Really I don't see use case where removing prefix is usefull. But in current state it breaks symlinks in /Users mount in docker-machine.
